### PR TITLE
chore(dev): update previous releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "description": "The world's most powerful conversational engine",
   "scripts": {
     "start": "cd website && yarn && yarn start",
-    "build": "cd website && yarn && yarn build"
+    "build": "cd website && yarn && yarn build",
+    "upd-master": "node update-version master",
+    "upd-dev": "node update-version dev"
   },
   "dependencies": {
+    "bluebird": "^3.7.2",
+    "bluebird-global": "^1.0.1",
     "prettier": "^2.4.0"
   }
 }

--- a/update-version.js
+++ b/update-version.js
@@ -1,0 +1,57 @@
+const fs = require('fs')
+const path = require('path')
+const _ = require('lodash')
+const { exec } = require('child_process')
+require('bluebird-global')
+
+const versionDocs = (files) => {
+  const version = require('./package.json').version
+
+  for (const file of files.filter((x) => x.startsWith('docs/'))) {
+    const versionedPath = `website/versioned_docs/version-${version}/${file.replace('docs/', '')}`
+
+    fs.mkdirSync(path.dirname(versionedPath), { recursive: true, mode: 0o700 })
+
+    const content = fs.readFileSync(file, 'utf-8')
+    const id = content.match(/id: (.*)/)
+    const title = content.match(/title: (.*)/)
+
+    const fixed = content
+      .replace(id[0], `id: version-${version}-${id[1]}`)
+      .replace(title[0], `title: ${title[1]}\noriginal_id: ${id[1]}`)
+
+    fs.writeFileSync(versionedPath, fixed)
+  }
+}
+
+/**
+ * Returns committed & staged files different from the specified branch
+ */
+const getChangedFiles = async (targetBranch) => {
+  const branch = await Promise.fromCallback((cb) => exec('git rev-parse --abbrev-ref HEAD', cb))
+
+  const committedDiff = await Promise.fromCallback((cb) =>
+    exec(`git diff --name-only ${branch.replace('\n', '')}..${targetBranch}`, cb)
+  )
+
+  const stagedDiff = await Promise.fromCallback((cb) => exec('git diff --name-only --cached', cb))
+
+  const addedModified = [...committedDiff.split('\n'), ...stagedDiff.split('\n')]
+    .map((x) => x.trim())
+    .filter((x) => x.length)
+
+  return _.uniq(addedModified)
+}
+
+const execute = async () => {
+  const targetBranch = process.argv.length > 2 ? process.argv[2] : undefined
+  if (targetBranch !== 'dev' && targetBranch !== 'master') {
+    console.error('Must be dev or master')
+    return
+  }
+
+  const files = await getChangedFiles(targetBranch)
+  await versionDocs(files)
+}
+
+execute()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+bluebird-global@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/bluebird-global/-/bluebird-global-1.0.1.tgz#147c174f4e3a19740e80d992ea70ec3dc51d0d95"
+  integrity sha512-llTREi0V3EUM150DKdMLlXN/X2QsQ/hWJDiaGnivqeDwE32I0dmivYLU9/VvhotTzvvbv7OiM6zjVXYJ2dCmKQ==
+
+bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
 prettier@^2.4.0:
   version "2.4.0"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.4.0.tgz#85bdfe0f70c3e777cf13a4ffff39713ca6f64cba"


### PR DESCRIPTION
Technically docusaurus doesn't makes it easy to update previously published documents. This is a small manual script which will create the versioned docs based on what files were changed in the PR. Automation would be possible once we're sure the script work fine