### PR TITLE
fix: update the number of stars on the doc website

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -41,7 +41,7 @@ class Footer extends React.Component {
             <a href="https://github.com/botpress">GitHub</a>
             <a
               className="github-button"
-              href={this.props.config.repoUrl}
+              href="https://github.com/botpress/botpress"
               data-icon="octicon-star"
               data-count-href="/botpress/botpress/stargazers"
               data-show-count="true"


### PR DESCRIPTION
I haven't tried it but I imagine the number of stars (3) is the number of stars of the doc repo se I simply hardcoded the botpress main repo there. 

We should try it first just to make sure we're good